### PR TITLE
Add testing support to bood

### DIFF
--- a/build/build.bood
+++ b/build/build.bood
@@ -1,10 +1,21 @@
 go_binary {
   // Module (and output) name.
   name: "bood",
-
   // Go package to build.
   pkg: "github.com/G1gg1L3s/design-practice-1/build/cmd/bood",
-
+  // Go package to test.
+  testPkg: "github.com/G1gg1L3s/design-practice-1/build/gomodule",
   // Build inputs.
-  srcs: ["**/*.go", "../go.mod"]
+  srcs: [
+    "**/*.go",
+    "../go.mod"
+  ],
+  // Exclude test sources
+  srcsExclude: [
+    "**/*_test.go"
+  ],
+  // Test sources.
+  testSrcs: [
+    "**/*_test.go"
+  ],
 }

--- a/build/cmd/bood/main.go
+++ b/build/cmd/bood/main.go
@@ -7,10 +7,9 @@ import (
 	"os"
 	"os/exec"
 
-	// "github.com/G1gg1L3s/design-practice-1/build/gomodule"
+	"github.com/G1gg1L3s/design-practice-1/build/gomodule"
 	"github.com/google/blueprint"
 	"github.com/roman-mazur/bood"
-	"github.com/roman-mazur/bood/gomodule"
 )
 
 var (
@@ -18,10 +17,10 @@ var (
 	verbose = flag.Bool("v", false, "Display debugging logs")
 )
 
+// NewContext creates new context with registered module
 func NewContext() *blueprint.Context {
 	ctx := bood.PrepareContext()
-	// TODO: Замініть імплементацію go_binary на власну.
-	ctx.RegisterModuleType("go_binary", gomodule.SimpleBinFactory)
+	ctx.RegisterModuleType("go_binary", gomodule.BinFactory)
 	return ctx
 }
 

--- a/build/gomodule/teste-binary_test.go
+++ b/build/gomodule/teste-binary_test.go
@@ -1,0 +1,49 @@
+package gomodule
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type PlugResolver struct {
+	errors []string
+}
+
+// Checks if slice contains element
+func contains(slice []string, el string) bool {
+	for _, a := range slice {
+		if a == el {
+			return true
+		}
+	}
+	return false
+}
+
+// Resolves patterns
+func (pg *PlugResolver) GlobWithDeps(src string, exclude []string) ([]string, error) {
+	// if this patterns should produce error, do it
+	if contains(pg.errors, src) {
+		return []string{}, fmt.Errorf("Wrong")
+	}
+	// if this patterns is excluded, return nothing
+	if contains(exclude, src) {
+		return []string{}, nil
+	}
+	// Otherwise return this pattern
+	return []string{src}, nil
+}
+
+func TestResolve(t *testing.T) {
+	// Patterns we want to resolve
+	patters := []string{"a", "b", "c", "a"}
+	// Patterns we don't want to resolve
+	exclude := []string{"a"}
+	// Patterns that will produce errors
+	plug := PlugResolver{errors: []string{"b"}}
+	resolved, unresolved := resolvePatterns(&plug, patters, exclude)
+	assert.True(t, reflect.DeepEqual(resolved, []string{"c"}))
+	assert.True(t, reflect.DeepEqual(unresolved, []string{"b"}))
+}

--- a/build/gomodule/tested-binary.go
+++ b/build/gomodule/tested-binary.go
@@ -110,7 +110,7 @@ func (tb *testedBinaryModule) GenerateBuildActions(ctx blueprint.ModuleContext) 
 		},
 	})
 
-	// Append our main binary to test input, so you ninja will rerun the tests
+	// Append our main binary to teGlobWithDepsst input, so ninja will rerun the tests
 	// if we change one of the sources
 	testInputs = append(testInputs, outputPath)
 
@@ -141,8 +141,14 @@ func reportUnresolved(ctx blueprint.ModuleContext, unresolved []string) {
 	}
 }
 
+// Interface for testing resolvePatterns. It decouples resolvePatterns from the
+// Specific struct to just an interface which helps testing.
+type globWithDeps interface {
+	GlobWithDeps(src string, exclude []string) ([]string, error)
+}
+
 // resolvePatterns returns resolved files and poorly constructed patterns
-func resolvePatterns(ctx blueprint.ModuleContext, patterns []string, exclude []string) ([]string, []string) {
+func resolvePatterns(ctx globWithDeps, patterns []string, exclude []string) ([]string, []string) {
 	var result = []string{}
 	var unresolved = []string{}
 

--- a/build/gomodule/tested-binary.go
+++ b/build/gomodule/tested-binary.go
@@ -1,15 +1,164 @@
 package gomodule
 
-import "github.com/google/blueprint"
+import (
+	"fmt"
+	"path"
 
+	"github.com/google/blueprint"
+	"github.com/roman-mazur/bood"
+)
+
+var (
+	// Package context used to define Ninja build rules.
+	pctx = blueprint.NewPackageContext("github.com/roman-mazur/bood/gomodule")
+
+	// Ninja rule to execute go build.
+	goBuild = pctx.StaticRule("binaryBuild", blueprint.RuleParams{
+		Command:     "cd $workDir && go build -o $outputPath $pkg",
+		Description: "build go command $pkg",
+	}, "workDir", "outputPath", "pkg")
+
+	// Ninja rule to execute go mod vendor.
+	goVendor = pctx.StaticRule("vendor", blueprint.RuleParams{
+		Command:     "cd $workDir && go mod vendor",
+		Description: "vendor dependencies of $name",
+	}, "workDir", "name")
+
+	goTest = pctx.StaticRule("gotest", blueprint.RuleParams{
+		Command:     "cd $workDir && go test -v $pkg > $outputPath",
+		Description: "Build and test $pkg",
+	}, "workDir", "pkg", "outputPath")
+)
+
+// goBinaryModuleType implements the simplest Go binary build without running tests for the target Go package.
 type testedBinaryModule struct {
 	blueprint.SimpleName
 
 	properties struct {
-		// TODO: Визначте поля структури, щоб отримати дані з визначень у файлі build.bood
+		// Go package name to build as a command with "go build".
+		Pkg string
+		// Go package name to test as a command with "go test".
+		TestPkg string
+		// List of source files.
+		Srcs []string
+		// List of test source files.
+		TestSrcs []string
+		// Exclude patterns.
+		SrcsExclude []string
+		// Test Exclude patterns.
+		TestSrcsExclude []string
+		// If to call vendor command.
+		VendorFirst bool
+		// Example of how to specify dependencies.
+		Deps []string
 	}
 }
 
+func (tb *testedBinaryModule) DynamicDependencies(blueprint.DynamicDependerModuleContext) []string {
+	return tb.properties.Deps
+}
+
 func (tb *testedBinaryModule) GenerateBuildActions(ctx blueprint.ModuleContext) {
-	// TODO: Імплементууйте генерацію правил збірки для ninja-файла.
+	name := ctx.ModuleName()
+	config := bood.ExtractConfig(ctx)
+	config.Debug.Printf("Adding build actions for go binary module '%s'", name)
+
+	// path to main binary
+	outputPath := path.Join(config.BaseOutputDir, "bin", name)
+	// resolve sources
+	inputs, unresolved := resolvePatterns(ctx, tb.properties.Srcs, tb.properties.SrcsExclude)
+	// if we have bad patterns, return
+	if len(unresolved) != 0 {
+		reportUnresolved(ctx, unresolved)
+		return
+	}
+
+	// resolve test sources
+	testInputs, unresolved := resolvePatterns(ctx, tb.properties.TestSrcs, tb.properties.TestSrcsExclude)
+	// if we have bad patterns, return
+	if len(unresolved) != 0 {
+		reportUnresolved(ctx, unresolved)
+		return
+	}
+
+	if tb.properties.VendorFirst {
+		vendorDirPath := path.Join(ctx.ModuleDir(), "vendor")
+		ctx.Build(pctx, blueprint.BuildParams{
+			Description: fmt.Sprintf("Vendor dependencies of %s", name),
+			Rule:        goVendor,
+			Outputs:     []string{vendorDirPath},
+			Implicits:   []string{path.Join(ctx.ModuleDir(), "go.mod")},
+			Optional:    true,
+			Args: map[string]string{
+				"workDir": ctx.ModuleDir(),
+				"name":    name,
+			},
+		})
+		inputs = append(inputs, vendorDirPath)
+	}
+
+	// Generate rule for the main build
+	ctx.Build(pctx, blueprint.BuildParams{
+		Description: fmt.Sprintf("Build %s as Go binary", name),
+		Rule:        goBuild,
+		Outputs:     []string{outputPath},
+		Implicits:   inputs,
+		Args: map[string]string{
+			"outputPath": outputPath,
+			"workDir":    ctx.ModuleDir(),
+			"pkg":        tb.properties.Pkg,
+		},
+	})
+
+	// Append our main binary to test input, so you ninja will rerun the tests
+	// if we change one of the sources
+	testInputs = append(testInputs, outputPath)
+
+	// test artifact
+	outTestPath := fmt.Sprintf(".%s.test.out", name)
+	outTestPath = path.Join(config.BaseOutputDir, outTestPath)
+
+	// Generate our rule for the tests
+	// It will produce test artifact which won't run the tests again if nothing changes
+	ctx.Build(pctx, blueprint.BuildParams{
+		Description: fmt.Sprintf("Testing %s", name),
+		Rule:        goTest,
+		Outputs:     []string{outTestPath},
+		Implicits:   testInputs,
+		Args: map[string]string{
+			"outputPath": outTestPath,
+			"workDir":    ctx.ModuleDir(),
+			"pkg":        tb.properties.TestPkg,
+		},
+	})
+
+}
+
+// reportUnresolved iterates over all patterns and prints error message
+func reportUnresolved(ctx blueprint.ModuleContext, unresolved []string) {
+	for _, pattern := range unresolved {
+		ctx.PropertyErrorf("srcs", "Cannot resolve files that match pattern %s", pattern)
+	}
+}
+
+// resolvePatterns returns resolved files and poorly constructed patterns
+func resolvePatterns(ctx blueprint.ModuleContext, patterns []string, exclude []string) ([]string, []string) {
+	var result = []string{}
+	var unresolved = []string{}
+
+	for _, src := range patterns {
+		if matches, err := ctx.GlobWithDeps(src, exclude); err == nil {
+			result = append(result, matches...)
+		} else {
+			unresolved = append(unresolved, src)
+		}
+	}
+
+	return result, unresolved
+}
+
+// BinFactory is a factory for go binary module type which supports Go command packages without running tests.
+func BinFactory() (blueprint.Module, []interface{}) {
+	mType := &testedBinaryModule{}
+	return mType, []interface{}{&mType.SimpleName.Properties, &mType.properties}
 }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.15
 require (
 	github.com/google/blueprint v0.0.0-20200305182927-215230a3e856
 	github.com/roman-mazur/bood v0.0.6
+	github.com/stretchr/testify v1.6.1
 )
 
 replace github.com/google/blueprint => github.com/roman-mazur/blueprint v0.0.0-20200310221250-fc31433fc3c0

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/roman-mazur/design-practice-1-template
+module github.com/G1gg1L3s/design-practice-1
 
 go 1.15
 

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,16 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/roman-mazur/blueprint v0.0.0-20200310221250-fc31433fc3c0 h1:WL72gfNCOF2vLPoXkvsVB+AYFKSfqeqfbAyeSXbkJ+c=
 github.com/roman-mazur/blueprint v0.0.0-20200310221250-fc31433fc3c0/go.mod h1:XjUnsvcdWlyS1DoCAZHjS8jPbP1bs2O3WSrDMgG7Bxc=
 github.com/roman-mazur/bood v0.0.5 h1:043rEpGuOId89qsj00pSZveRovo03VXAchql9qMXOnc=
 github.com/roman-mazur/bood v0.0.5/go.mod h1:w66c0jFfvSmRX1lP0p5kwz4373VuJYOhX02O6cQxFgc=
 github.com/roman-mazur/bood v0.0.6 h1:Nt63/h6V0IZPcOH5us+AqpXq81Tt2IClt9iN0ETjBAc=
 github.com/roman-mazur/bood v0.0.6/go.mod h1:w66c0jFfvSmRX1lP0p5kwz4373VuJYOhX02O6cQxFgc=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Now bood supports package testing. In build.bood you can find new keys:
`testPkg` - package you want to test (only one).
`testSrcs` - testing sources that will be tracked.
`testSrcrsExclude` - testing sources you want to exclude.
Also, I add new version of bood to `bootstrap/bood` for bootstraping this package.
To build it:
```
$ cd build
$ ../bootstrap/bood
```
And your version of bood will be located at `build/out/bin/bood`