### PR TITLE
Benches and tests without binary suport

### DIFF
--- a/build/gomodule/tested-binary.go
+++ b/build/gomodule/tested-binary.go
@@ -25,9 +25,9 @@ var (
 	}, "workDir", "name")
 
 	goTest = pctx.StaticRule("gotest", blueprint.RuleParams{
-		Command:     "cd $workDir && go test -v $pkg > $outputPath",
+		Command:     "cd $workDir && go test -v $pkg $bench > $outputPath",
 		Description: "Build and test $pkg",
-	}, "workDir", "pkg", "outputPath")
+	}, "workDir", "pkg", "outputPath", "bench")
 )
 
 // goBinaryModuleType implements the simplest Go binary build without running tests for the target Go package.
@@ -47,6 +47,8 @@ type testedBinaryModule struct {
 		SrcsExclude []string
 		// Test Exclude patterns.
 		TestSrcsExclude []string
+		// Patter for benchmarks
+		Bench string
 		// If to call vendor command.
 		VendorFirst bool
 		// Example of how to specify dependencies.
@@ -118,6 +120,10 @@ func (tb *testedBinaryModule) GenerateBuildActions(ctx blueprint.ModuleContext) 
 	outTestPath := fmt.Sprintf(".%s.test.out", name)
 	outTestPath = path.Join(config.BaseOutputDir, outTestPath)
 
+	bench := ""
+	if tb.properties.Bench != "" {
+		bench = fmt.Sprintf("-bench=%s", tb.properties.Bench)
+	}
 	// Generate our rule for the tests
 	// It will produce test artifact which won't run the tests again if nothing changes
 	ctx.Build(pctx, blueprint.BuildParams{
@@ -129,6 +135,7 @@ func (tb *testedBinaryModule) GenerateBuildActions(ctx blueprint.ModuleContext) 
 			"outputPath": outTestPath,
 			"workDir":    ctx.ModuleDir(),
 			"pkg":        tb.properties.TestPkg,
+			"bench":      bench,
 		},
 	})
 

--- a/build/gomodule/tested-binary.go
+++ b/build/gomodule/tested-binary.go
@@ -99,22 +99,23 @@ func (tb *testedBinaryModule) GenerateBuildActions(ctx blueprint.ModuleContext) 
 		inputs = append(inputs, vendorDirPath)
 	}
 
-	// Generate rule for the main build
-	ctx.Build(pctx, blueprint.BuildParams{
-		Description: fmt.Sprintf("Build %s as Go binary", name),
-		Rule:        goBuild,
-		Outputs:     []string{outputPath},
-		Implicits:   inputs,
-		Args: map[string]string{
-			"outputPath": outputPath,
-			"workDir":    ctx.ModuleDir(),
-			"pkg":        tb.properties.Pkg,
-		},
-	})
-
-	// Append our main binary to teGlobWithDepsst input, so ninja will rerun the tests
-	// if we change one of the sources
-	testInputs = append(testInputs, outputPath)
+	// Generate rule for the main build if the pkg field is present
+	if tb.properties.Pkg != "" {
+		ctx.Build(pctx, blueprint.BuildParams{
+			Description: fmt.Sprintf("Build %s as Go binary", name),
+			Rule:        goBuild,
+			Outputs:     []string{outputPath},
+			Implicits:   inputs,
+			Args: map[string]string{
+				"outputPath": outputPath,
+				"workDir":    ctx.ModuleDir(),
+				"pkg":        tb.properties.Pkg,
+			},
+		})
+		// Append our main binary to teGlobWithDepsst input, so ninja will rerun the tests
+		// if we change one of the sources
+		testInputs = append(testInputs, outputPath)
+	}
 
 	// test artifact
 	outTestPath := fmt.Sprintf(".%s.test.out", name)

--- a/example/build.bood
+++ b/example/build.bood
@@ -17,6 +17,7 @@ go_binary {
   testSrcs: [
     "**/*_test.go"
   ],
+  bench: "."
 }
 
 

--- a/example/example_bin/example_bin_test.go
+++ b/example/example_bin/example_bin_test.go
@@ -1,10 +1,43 @@
 package example_bin
 
-import "testing"
+import (
+	"testing"
+)
 
 func Test(t *testing.T) {
 	res := getName("Red", "Stone")
 	if res != "Red Stone Team" {
 		t.Error("Error", res)
+	}
+}
+
+// This is the XorShift random generator
+type XorShiftRng struct {
+	x, y, z, w uint32
+}
+
+// The code is from [here](https://docs.rs/rand/0.5.0/src/rand/prng/xorshift.rs.html#29-34)
+func (rng *XorShiftRng) next_u32() uint32 {
+	x := rng.x
+	t := x ^ (x << 11)
+	rng.x = rng.y
+	rng.y = rng.z
+	rng.z = rng.w
+	w := rng.w
+	rng.w = w ^ (w >> 19) ^ (t ^ (t >> 8))
+	return rng.w
+}
+
+func BenchmarkSomething(b *testing.B) {
+	// you may ask, why I implemented it here?
+	// I dunno, just for fun :)
+	rng := XorShiftRng{
+		x: 0xbad5eed,
+		y: 0xbad5eed,
+		z: 0xbad5eed,
+		w: 0xbad5eed,
+	}
+	for n := 0; n < b.N; n++ {
+		_ = rng.next_u32()
 	}
 }

--- a/go.sum
+++ b/go.sum
@@ -4,13 +4,12 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/roman-mazur/blueprint v0.0.0-20200310221250-fc31433fc3c0 h1:WL72gfNCOF2vLPoXkvsVB+AYFKSfqeqfbAyeSXbkJ+c=
 github.com/roman-mazur/blueprint v0.0.0-20200310221250-fc31433fc3c0/go.mod h1:XjUnsvcdWlyS1DoCAZHjS8jPbP1bs2O3WSrDMgG7Bxc=
-github.com/roman-mazur/bood v0.0.5 h1:043rEpGuOId89qsj00pSZveRovo03VXAchql9qMXOnc=
-github.com/roman-mazur/bood v0.0.5/go.mod h1:w66c0jFfvSmRX1lP0p5kwz4373VuJYOhX02O6cQxFgc=
 github.com/roman-mazur/bood v0.0.6 h1:Nt63/h6V0IZPcOH5us+AqpXq81Tt2IClt9iN0ETjBAc=
 github.com/roman-mazur/bood v0.0.6/go.mod h1:w66c0jFfvSmRX1lP0p5kwz4373VuJYOhX02O6cQxFgc=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
This pull request adds two features:
- new `bench` field in `build.bood`, where you can specify the patter for the benches.
- tests now can be running without the binary